### PR TITLE
Recommend out-of-process runners for web farms

### DIFF
--- a/articles/quickstart.md
+++ b/articles/quickstart.md
@@ -44,10 +44,10 @@ This will create a table named `Log` with the columns `Id`, and `Text`.
 
 You have two options to execute your migration:
 
-* Using an in-process runner (preferred)
-* Using an out-of-process runner (for some corporate requirements)
+* Using an in-process runner (preferred when running from a single process)
+* Using an out-of-process runner (for some corporate requirements or when running from multiple processes)
 
-## [In-Process (preferred)](#tab/runner-in-process)
+## [In-Process (preferred when running from a single process)](#tab/runner-in-process)
 
 Change your `Program.cs` to the following code:
 
@@ -56,7 +56,7 @@ Change your `Program.cs` to the following code:
 As you can see, instantiating the [migration runner](xref:FluentMigrator.Runner.IMigrationRunner) (in `UpdateDatabase`) becomes
 very simple and updating the database is straight-forward.
 
-## [Out-of-process (for some corporate requirements)](#tab/runner-dotnet-fm)
+## [Out-of-process (for some corporate requirements or when running from multiple processes)](#tab/runner-dotnet-fm)
 
 > [!IMPORTANT]
 > You need at least the .NET Core 2.1 preview 2 SDK for this tool.


### PR DESCRIPTION
As mentioned in #996, running FluentMigrator from an application that is running multiple instances is not yet supported because the necessary locking isn't in place to avoid conflicts. Currently the documentation is ambiguous because it can be interpreted as recommending that a web farm scenario supports FluentMigrations in-process.