### PR TITLE
Added PostgreSQL 10.0

### DIFF
--- a/snippets/supported-databases.md
+++ b/snippets/supported-databases.md
@@ -10,6 +10,7 @@ Microsoft SQL Server 2000 | SqlServer2000 | SqlServer
 Microsoft SQL Server Compact Edition | SqlServerCe | SqlServer
 PostgreSQL | Postgres | PostgreSQL
 PostgreSQL 9.2 | Postgres92 | PostgreSQL92
+PostgreSQL 10.0 | PostgreSQL10_0 | PostgreSQL
 MySQL 4 | MySql4 | MySql
 MySQL 5 | MySql5 | MySql, MariaDB
 Oracle  | Oracle |


### PR DESCRIPTION
Now that https://github.com/fluentmigrator/fluentmigrator/releases/tag/v3.2.8 has been released, it is appropriate to update the supported databases to reflect the addition of https://github.com/fluentmigrator/fluentmigrator/pull/1272.

Consumers must specify this identifier to ensure that any columns specified as Identity will generate PostgresSQL 10-compatible identity columns instead of `serial` or `bigserial` used in earlier versions.
See https://www.postgresql.org/docs/10/sql-createtable.html for the SQL syntax. 