### PR TITLE
Certificate error for SQL Connection

### DIFF
--- a/articles/faq.md
+++ b/articles/faq.md
@@ -174,3 +174,7 @@ END;
             ");
     }
 ```
+
+## Certificate error for SQL Connection
+
+Since the use of `Microsoft.Data.SqlClient` version `4.0.0` connections are encrypted by default in .NET. You might start getting the exception: `A connection was successfully established with the server, but then an error occurred during the login process. (provider: SSL Provider, error: 0 - The certificate chain was issued by an authority that is not trusted.)`. If fixing a valid certificate isn't a feasable path, you can always disable the encryption by adding `Encrypt=False` to the connection string. Then the connection won't be encryptet, and thus no certificate needed. As a note; you can also add `TrustServerCertificate=True` to the connection string, if you have a self-signed certificate or similar. But it's probably a better idea to fix a real certificate, or skip encryption all together.


### PR DESCRIPTION
Added a section on how to handle certificate errors for SQL Connections. I did not take the time to group the FAQ in an SQL section. I'm also not sure I'm the right person to make that decision and start grouping things.